### PR TITLE
[Fixit Q4 2022] Add official splunk repository + bump cdap and hadoop…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,17 +29,17 @@
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- version properties -->
-    <cdap.version>6.1.2</cdap.version>
-    <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
-    <hadoop.version>2.8.0</hadoop.version>
-    <spark2.version>2.3.1</spark2.version>
+    <cdap.version>6.8.0</cdap.version>
+    <hydrator.version>2.10.0</hydrator.version>
+    <hadoop.version>2.10.2</hadoop.version>
+    <spark2.version>2.4.8</spark2.version>
     <netty.version>4.1.16.Final</netty.version>
     <netty-http.version>1.3.0</netty-http.version>
     <httpcomponents.version>4.5.9</httpcomponents.version>
     <guava.retrying.version>2.0.0</guava.retrying.version>
     <commons-codec.version>1.4</commons-codec.version>
     <commons-validator.version>1.4.1</commons-validator.version>
-    <splunk.version>1.6.3.0</splunk.version>
+    <splunk.version>1.9.3</splunk.version>
     <awaitility.version>3.1.6</awaitility.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
@@ -58,8 +58,8 @@
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </repository>
     <repository>
-      <id>spring</id>
-      <url>https://repo.spring.io/plugins-release/</url>
+      <id>splunk-artifactory</id>
+      <url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
     </repository>
   </repositories>
 
@@ -389,8 +389,8 @@
           <version>1.1.0</version>
           <configuration>
             <cdapArtifacts>
-              <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-              <parent>system:cdap-data-streams[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-streams[6.8.0,7.0.0-SNAPSHOT)</parent>
             </cdapArtifacts>
           </configuration>
           <executions>


### PR DESCRIPTION
There were [permissions changes](https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020) for `repo.spring.io` that caused fetching artifacts to fail. Added splunk's jfrog repository as suggested in the [Splunk Java SDK repository](https://github.com/splunk/splunk-sdk-java).

<img width="579" alt="1" src="https://user-images.githubusercontent.com/114443254/207175869-a0fa4204-d984-4796-8832-f0163fc32c7a.png">
log4j is now only in the `test` scope

<img width="430" alt="2" src="https://user-images.githubusercontent.com/114443254/207176017-0961cede-5db5-4c6d-aafa-2ed3d581fc61.png">
Build and unit tests passing
